### PR TITLE
Add preset supertexts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
-﻿<html>
+<html>
 <head>
     <title>Article cover generator - Godot Engine</title>
-    <link rel="stylesheet" href="styles/normalize.css" />
-    <link rel="stylesheet" href="styles/main.css" />
+    <link rel="stylesheet" href="normalize.css" />
+    <link rel="stylesheet" href="main.css" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-    <script src="scripts/main.js"></script>
+    <script src="main.js"></script>
 
     <div class="content">
         <div class="toolbar">
@@ -34,6 +34,13 @@
             <div class="toolbar-item">
                 <label for="super-text">Supertext</label>
                 <input type="text" id="super-text" value="" />
+                <label>Preset supertexts</label>
+                <div class="toolbar-item-controls">
+                    <button id="preset-super-1">Progress report</button>
+                    <button id="preset-super-2">Dev snapshot</button>
+                    <button id="preset-super-3">Maintenance release</button>
+                    <button id="preset-super-4">Release candidate</button>
+                </div>
             </div>
 
             <div class="toolbar-spacer"></div>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <html>
 <head>
     <title>Article cover generator - Godot Engine</title>
-    <link rel="stylesheet" href="normalize.css" />
-    <link rel="stylesheet" href="main.css" />
+    <link rel="stylesheet" href="styles/normalize.css" />
+    <link rel="stylesheet" href="styles/main.css" />
 	<link rel="preconnect" href="https://fonts.googleapis.com" />
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-    <script src="main.js"></script>
+    <script src="scripts/main.js"></script>
 
     <div class="content">
         <div class="toolbar">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -165,6 +165,20 @@ class PreviewGenerator {
         downloadImage_button.addEventListener("click", () => {
             this._saveRender();
         });
+
+        // Event listeners for preset supertext buttons
+        document.getElementById("preset-super-1").addEventListener("click", () => {
+            this._setSuperText("Progress report");
+        });
+        document.getElementById("preset-super-2").addEventListener("click", () => {
+            this._setSuperText("Dev snapshot");
+        });
+        document.getElementById("preset-super-3").addEventListener("click", () => {
+            this._setSuperText("Maintenance release");
+        });
+        document.getElementById("preset-super-4").addEventListener("click", () => {
+            this._setSuperText("Release candidate");
+        });
     }
 
     _initEvents() {
@@ -449,4 +463,11 @@ class PreviewGenerator {
         fakeAnchor.setAttribute("href", imageData);
         fakeAnchor.click();
     }
+
+    _setSuperText(text) {
+        const superText_input = document.getElementById("super-text");
+        superText_input.value = text;
+        this._debounceUpdateAndRender();
+    }
+
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -52,12 +52,12 @@ body {
 .toolbar-item {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 4px;
 }
 
 .toolbar-item label {
     cursor: pointer;
-    font-size: 16px;
+    font-size: 14px;
 }
 
 .toolbar-item input[type=file] {
@@ -69,9 +69,11 @@ body {
     border: none;
     color: var(--button-text-color);
     cursor: pointer;
-    font-size: 16px;
+    font-size: 12px;
     font-weight: 600;
-    padding: 8px 16px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    transition: background 0.3s;
 }
 .toolbar-item button:hover {
     background: var(--button-hover-color);
@@ -98,14 +100,14 @@ body {
 }
 
 .toolbar-item-controls button {
-    font-size: 12px;
-    padding: 4px 10px;
+    font-size: 10px; 
+    padding: 4px 8px;
 }
 
 .toolbar-filename-label {
     color: var(--text-faint-color);
     cursor: help;
-    font-size: 14px;
+    font-size: 12px;
     text-align: right;
 }
 
@@ -129,6 +131,8 @@ body {
 /* CANVAS STYLING. */
 
 .canvas-container {
+    width: 960px; 
+    height: 540px;
     max-height: 540px;
     aspect-ratio: 16 / 9;
 }
@@ -136,4 +140,28 @@ body {
 .canvas-container > canvas {
     width: 100%;
     height: 100%;
+}
+
+/* MEDIA QUERIES FOR RESPONSIVENESS. */
+
+@media (max-width: 768px) {
+    .content {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    
+    .toolbar {
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+    
+    .toolbar-item {
+        flex: 1 1 100%;
+    }
+    
+    .toolbar-item--oneline {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 }


### PR DESCRIPTION
This PR adds preset supertext buttons that make it faster for common supertexts. The buttons include 'Progress report', 'Dev snapshot', 'Maintenance release', and 'Release candidate', which populate the 'super-text' input field when clicked.

![image](https://github.com/godotengine/godot-website-cover-generator/assets/80784920/7483d694-32c2-4f66-ba1f-f304db42541e)