### PR TITLE
Remove `letterSpacing` outdated info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A serverless cover generator for the Godot blog. Uses HTML canvas for rendering, so results might slightly differ between browsers.
 
-Currently relies on `letterSpacing` being available for the canvas 2D context, which doesn't work in Firefox or Safari (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/letterSpacing)).
-
 ## License
 
 This project is provided under the [MIT License](LICENSE.md).


### PR DESCRIPTION
Since 2025, [`letterSpacing` is available on all main browsers](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/letterSpacing).